### PR TITLE
Memory cache + Biome API

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -11,8 +11,8 @@
 
 ]]--
 
-local wp = minetest.get_worldpath() .. "/luscious"
-minetest.mkdir(wp)
+gt = {}
+tablesize = 0
 
 local mgp = minetest.get_mapgen_params()
 local chunksize = 16 * mgp.chunksize
@@ -28,25 +28,33 @@ local function cmpy(p2, y)
 		return math.max(1, p2)
 	end
 end
+
+local function chose_color(pos)
+	-- Calculate color from biome heat and humidity.
+	local biome_data = minetest.get_biome_data(pos)
+	local hum1 = biome_data.humidity
+	local temp1 = biome_data.heat 
+	local vh = math.floor(math.min(math.max(math.floor(hum1), 0), 100) / 6.6)
+	local vt = math.floor(math.min(math.max(math.floor(temp1), 0), 100) / 6.6)
+	vt = vt - math.max(math.min(vt, math.floor(pos.y / 16)), 0)
+	return vh * 16 + vt
+end
+
 local function on_construct(pos)
 	-- get chunk from pos
 	local v = vector.apply(pos, function(a) return math.floor((a - 48) / chunksize) end)
 	local o = vector.subtract(pos, vector.apply(v, function(a) return (a * chunksize) + 48 end))
 	local l = o.z * (chunksize) + o.x
 	local p = minetest.hash_node_position(v)
-
-	local f = io.open(wp .. "/" .. string.format("%d", p), "r")
-	if not f then
-		minetest.log("error", "unable to find map for " .. string.format("%d", p))
-		return
-	end
-
-	local z = f:read("*a")
-	f:close()
-	local map = minetest.decompress(z)
-
+	local map = gt[p]
+	local mv = 0
 	local node = minetest.get_node(pos)
-	node.param2 = cmpy(string.byte(map, l + 1), pos.y)
+	if map == nil then
+		mv = chose_color(pos) 
+	else
+		mv = cmpy(string.byte(map, l + 1), pos.y)
+	end
+	node.param2 = mv
 	minetest.swap_node(pos, node)
 end
 
@@ -146,12 +154,14 @@ minetest.register_on_generated(function(minp, maxp, blockseed)
 		h2 = math.floor(math.min(math.max(math.floor(h2), 0), 100) / 6.6)
 		map = map .. string.char(h1 + (h2 * 16))
 	end
-	local p = string.format("%d", minetest.hash_node_position(v))
-
-	local f = assert(io.open(wp .. "/" .. p, "w"), wp .. "/" .. p)
-	f:write(minetest.compress(map))
-	f:close()
-
+	local p = minetest.hash_node_position(v)
+	if tablesize > 75 then
+		gt = {}
+		collectgarbage()
+		tablesize = 0
+	end
+	tablesize = tablesize + 1
+	gt[p] = map
 	local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
 	local area = VoxelArea:new{MinEdge = emin, MaxEdge = emax}
 	local data = vm:get_data()


### PR DESCRIPTION
The maps are kept in memory for the mapgen to work with.  Once the map are discarded it use the biome api instead. 

The initial map generation noticeably faster  with memory and no drive IO. 

The slower biome api is only used on older world with missing colors or when we do manual change later like adding block planting tree ect... 


