### PR TITLE
don't convert default:dry_grass_{4,5} to default:grass_{4,5}

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -94,10 +94,12 @@ for _, v in pairs({
 	"default:grass_3",
 	"default:grass_4",
 	"default:grass_5",
+	"default:dry_grass_4",
+	"default:dry_grass_5",
 	"default:junglegrass",
 }) do
 	local def = minetest.registered_nodes[v]
-	local tile, _ = def.tiles[1]:gsub("default_", "luscious_")
+	local tile, _ = def.tiles[1]:gsub("dry_", ""):gsub("default_", "luscious_")
 	minetest.override_item(v, {
 		paramtype2 = "color",
 		palette_index = 136,
@@ -108,7 +110,7 @@ for _, v in pairs({
 		on_construct = on_construct,
 	})
 end
-for i = 1, 5 do
+for i = 1, 3 do
 	minetest.register_alias_force("default:dry_grass_" .. i, "default:grass_" .. i)
 end
 


### PR DESCRIPTION
In "farming" different drops are defined for `default:grass_4` and `default:dry_grass_4` as well as for `default:grass_5` and `default:dry_grass_5`. See https://notabug.org/TenPlus1/farming/src/master/grass.lua

But here https://github.com/sofar/luscious/blob/master/init.lua#L112 the drops from `default:grass_4` and `default:grass_5`are lost so far.

This PR fixes the problem.