### PR TITLE
Replace deprecated call to minetest.get_mapgen_params

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -14,8 +14,7 @@
 local wp = minetest.get_worldpath() .. "/luscious"
 minetest.mkdir(wp)
 
-local mgp = minetest.get_mapgen_params()
-local chunksize = 16 * mgp.chunksize
+local chunksize = 16 * minetest.get_mapgen_setting("chunksize")
 
 local function cmpy(p2, y)
 	if y > 0 then


### PR DESCRIPTION
According to https://github.com/minetest/minetest/blob/master/doc/lua_api.txt, `get_mapgen_params` is deprecated. Replacing with the approved `get_mapgen_setting(name)`.